### PR TITLE
Remove .rs external crate explicit imports

### DIFF
--- a/Web/src/core/display_language_selector.rs
+++ b/Web/src/core/display_language_selector.rs
@@ -1,6 +1,3 @@
-extern crate wacm;
-extern crate wasm_bindgen;
-
 use wasm_bindgen::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use wacm::Component;

--- a/Web/src/core/header.rs
+++ b/Web/src/core/header.rs
@@ -1,5 +1,3 @@
-extern crate wacm;
-
 use wasm_bindgen::prelude::*;
 use wacm::Component;
 use super::display_language_selector;

--- a/Web/src/core/nav_bar.rs
+++ b/Web/src/core/nav_bar.rs
@@ -1,5 +1,3 @@
-extern crate wacm;
-
 use wacm::Component;
 use crate::repos::{ pages };
 

--- a/Web/src/core/target_language_selector.rs
+++ b/Web/src/core/target_language_selector.rs
@@ -1,6 +1,3 @@
-extern crate wacm;
-extern crate wasm_bindgen;
-
 use wasm_bindgen::prelude::*;
 use std::sync::atomic::{AtomicBool, Ordering};
 use wacm::Component;

--- a/Web/src/lib.rs
+++ b/Web/src/lib.rs
@@ -1,7 +1,3 @@
-extern crate cfg_if;
-extern crate wasm_bindgen;
-extern crate wacm;
-
 use cfg_if::cfg_if;
 use wasm_bindgen::prelude::*;
 use wacm::Component;


### PR DESCRIPTION
Not required with rust 2018, should have been removed a while ago